### PR TITLE
Allowed spaced in GIT_DIR, SED and SE_DIR

### DIFF
--- a/utils/config.bat
+++ b/utils/config.bat
@@ -7,17 +7,17 @@ SET SE_SCRIPTS_DIR=%SE_DIR%\IngameScripts\local
 SET CS=Script.cs
 SET PNG=thumb.png
 
-IF NOT EXIST %GIT_DIR% (
-    ECHO Git is not found in "%GIT_DIR%". Use path without spaces.
+IF NOT EXIST "%GIT_DIR%" (
+    ECHO Git is not found in "%GIT_DIR%".
     EXIT /B 1
 )
 
-IF NOT EXIST %SED% (
+IF NOT EXIST "%SED%" (
     ECHO Sed editor is not found in "%SED%".
     EXIT /B 2
 )
 
-IF NOT EXIST %SE_DIR% (
+IF NOT EXIST "%SE_DIR%" (
     ECHO Space Engineers AppData is not found in "%SE_DIR%".
     EXIT /B 3
 )

--- a/utils/create.bat
+++ b/utils/create.bat
@@ -30,7 +30,7 @@ IF %ERRORLEVEL% NEQ 0 (
 
 SET dest_cs=%dest_dir%\%CS%
 
-%SED% "s/Template/%name%/" "%src_cs%" > "%dest_cs%"
+"%SED%" "s/Template/%name%/" "%src_cs%" > "%dest_cs%"
 
 SET src_png=%template_dir%\%PNG%
 SET dest_png=%dest_dir%\%PNG%

--- a/utils/export.bat
+++ b/utils/export.bat
@@ -55,13 +55,13 @@ REM Set ingame region patterns based on namespace.
 SET region="/^\s*#region %namespace%/="
 SET endregion="/^\s*#endregion \/\/ %namespace%/="
 REM Find and save the bounds of the ingame region.
-%SED% -n %region% "%src_cs%" > "%tmp%"
+"%SED%" -n %region% "%src_cs%" > "%tmp%"
 SET /P start_line_num= < "%tmp%"
-%SED% -n %endregion% "%src_cs%" > "%tmp%"
+"%SED%" -n %endregion% "%src_cs%" > "%tmp%"
 SET /P end_line_num= < "%tmp%"
 
 REM Copy the raw ingame script part.
-%SED% -n "%start_line_num%,%end_line_num%p" "%src_cs%" > "%tmp%"
+"%SED%" -n "%start_line_num%,%end_line_num%p" "%src_cs%" > "%tmp%"
 IF %ERRORLEVEL% NEQ 0 (
     ECHO Can not extract ingame script part.
     DEL "%tmp%"
@@ -72,7 +72,7 @@ IF %ERRORLEVEL% NEQ 0 (
 REM Remove first indent (tab or 4 spaces) at the start of each line.
 REM Save the script into the final file.
 SET TAB_STOP=4
-%SED% "s/^\(\s\{%TAB_STOP%\}\|\t\)//" "%tmp%" > "%dest_dir%\%CS%"
+"%SED%" "s/^\(\s\{%TAB_STOP%\}\|\t\)//" "%tmp%" > "%dest_dir%\%CS%"
 
 DEL "%tmp%"
 


### PR DESCRIPTION
I had an issue with my GIT being installed at `C:\Program Files\Git` but obviously, spaces wasn't allowed.
I couldn't see a reason why not, so I fixed it and decided to make a simple PR for it.