### PR TITLE
Add "usebackq delims=" to config.bat

### DIFF
--- a/utils/config.bat
+++ b/utils/config.bat
@@ -7,7 +7,7 @@ set PNG=thumb.png
 
 set git_dir=
 
-for /f %%i in ('where git 2^>NUL') do (
+for /f "usebackq delims=" %%i in (`where git 2^>NUL`) do (
   set git_dir=%%~dpi..
 )
 


### PR DESCRIPTION
This will ensure that whitespace in directory structures is handled correctly. Fixes issue #2